### PR TITLE
Enhance keyboard navigation, bugfixes, options.

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -16,7 +16,7 @@ var HN = {
 		$('.comment *').css({"color" : "#373736"});
 		$('.comment').each(function(){
 			$(this).parent().addClass('comment-container')
-		})
+		});
 		$('td[bgcolor="#ff6600"]').css({"backgroundColor" : "none !important"});
 		$('img').each(function(){
       var src = $(this).attr("src");
@@ -212,13 +212,13 @@ var HN = {
 	},
 
 	/**
-	 * If next element is found, highlight it and then remove previous comment highlight
+	 * If next element is found, highlight/focus on it, and remove previous comment highlight
 	 * @param  string type 		Specify if this is for comment or story headline
 	 * @param  current_elem		Currently focused element
 	 * @param  next_elem   		jQuery Collection or Single Result from jQuery find() method (should be single result, or empty collection)
 	 */
 	focus_next: function(type, current_elem, next_elem){
-			// if no next element was found in jQuery Collection, return null and leave original highlighted
+			// If no next element was found in jQuery Collection, return null and leave original highlighted
 			if (next_elem.length < 1) {
   	    	return;
       }
@@ -245,9 +245,14 @@ var HN = {
 	    }
 	},
 
+	/**
+	 * Attempts to open the currently selected story (and comments discussion page)
+	 * In two new background tabs
+	 */
 	open_story_and_comments: function(){
 	    if ($('.on_story').length != 0) {
 	    		var story = $('.on_story');
+	    		// Send message to the background page to open this story in a new tab
 		  		chrome.extension.sendMessage({
 		  			open_url_in_tab: {
 		  				url: story.attr('href'), 
@@ -273,11 +278,20 @@ var HN = {
 	    }
 	},
 
+	/**
+	 * Upvotes a story or comment (if selected)
+	 */
   upvote: function(){
       if ($('.on_story').length != 0) {
           var story = $('.on_story');
           var upvote_button = story.parent().prev().find('a:first');
           if (upvote_button) {
+            upvote_button.click();
+          }
+      } else if ($('.on_comment').length != 0) {
+      		var current = $('.on_comment');
+        	var upvote_button = current.prev().find('a:first');
+        	if (upvote_button) {
             upvote_button.click();
           }
       }


### PR DESCRIPTION
- Bug fixes:
  - Added check for next/previous stories to fix errors that were popping up when using keyboard navigation
  - Removed non-existant "h" keybind, as the help function did not exist.
  - Fixed bug where keybinds would stay active when submitting a new HN story, causing the page to navigate behind modal when typing.
- New Keybinds
  - Using j and k will now also browse up and down through comment pages, highlighting the comment you're actively reading.
    ![Screen Shot 2013-03-03 at 2 37 25 PM](https://f.cloud.github.com/assets/566763/214656/d1e92d84-8439-11e2-9204-1458932bfa1a.png)
  - Pressing "a" will now upvote the currently selected story or comment.
  - Pressing "l" will now open a story and related comments, each in new (unfocused) background tabs. I added this feature so that a user could browse the HN home page, opening stories & comments that they find interesting, and continue browsing. 
    To build this functionality, it was necessary to add a background page to create new tabs. Chrome content_scripts do not have access to chrome.tabs, only background/event pages can access or modify tabs. No extra permissions were needed for creating tabs.

For more info on:

  Tabs: http://developer.chrome.com/extensions/tabs.html

  Messaging: https://developer.chrome.com/extensions/messaging.html
![Screen Shot 2013-03-03 at 2 16 24 PM](https://f.cloud.github.com/assets/566763/214655/9cdca6f2-8439-11e2-86b6-51cf4c0cb6a5.png)
- Options page
  - Disabling Hotkeys: I was reading through reviews on the Chrome Extension page, and a user mentioned that they loved the design but the keybinds were a dealbreaker.
    "Makes HN readable and lovely, but really needs the ability to disable the keyboard controls."
    I agree that having keybinds on permanently can cause issues with other plugins, so I added an options page. Unfortunately this required adding the permission to use Storage to the manifest.json file. I decided to go with chrome.storage instead of localStorage, to avoid having to use a background page to retrieve user preferences from the hn.js content script.

For more into on chrome.storage:
  https://developer.chrome.com/extensions/storage.html

 If you'd prefer that I remove this options page from the pull request, please let me know  and I'll resubmit the pull request without it.
![Screen Shot 2013-03-03 at 2 29 15 PM](https://f.cloud.github.com/assets/566763/214657/efc09086-8439-11e2-9fc5-c924415f51ec.png)

![Screen Shot 2013-03-03 at 2 29 02 PM](https://f.cloud.github.com/assets/566763/214658/f6e11318-8439-11e2-9691-7d23ba389ab8.png)
